### PR TITLE
(feat) Abstracted action bar and provided classes for animated opening

### DIFF
--- a/client/css/eventfull.css
+++ b/client/css/eventfull.css
@@ -6,6 +6,14 @@ body {
   font-family: 'Alegreya Sans', sans-serif;
 }
 
+h2 {
+  font-size: 22px;
+  font-weight: 800;
+  font-style: italic;
+  text-align: center;
+  color: #7198C5;
+}
+
 h3 {
   font-size: 18px;
   font-weight: 800;
@@ -32,7 +40,9 @@ h5{
 /*
  * Form styles
  */
-
+form{
+  margin-top: 40px;
+}
 
 input{
   background: #FFFFFF;
@@ -42,7 +52,8 @@ input{
   text-align: center;
   display: block;
   width: 100%;
-  margin: 5px 0;
+  margin: 7px 0;
+  line-height: 35px;
 }
 
 input[type=submit]{
@@ -207,4 +218,47 @@ input[type=submit]{
   border: 1px solid #DADADA;
   border-radius: 3px;
   margin: 5px auto;
+}
+
+/*
+ * Action-bar and schedule view push styling
+ */
+
+.action-bar-default {
+  border-right: 1px solid #DADADA;
+  background: #F1F3F9;
+  position: fixed;
+  width: 16.666666667%;
+  width: calc(100% / 6);
+  height: 100%;
+  top: 0;
+  left: 0;
+  z-index: 999;
+}
+
+.action-bar-default.action-bar-open {
+  left: 16.666666667%;
+  left: calc(100% / 6);
+}
+
+/* Push classes applied to the schedule */
+
+.schedule-default {
+  overflow-x: hidden;
+  position: relative;
+  z-index: 998;
+}
+
+.schedule-default.schedule-push-right {
+  left: 16.666666667%;
+  left: calc(100% / 6);
+}
+
+/* Transitions */
+
+.action-bar-default,
+.schedule-default {
+  -webkit-transition: all 0.5s ease;
+  -moz-transition: all 0.5s ease;
+  transition: all 0.5s ease;
 }

--- a/client/js/app.js
+++ b/client/js/app.js
@@ -5,6 +5,7 @@ var Router = require('react-router-component');
 var Template = require('./components/app-template.js');
 var Month = require('./components/month/month.js');
 var Week = require('./components/week/week.js');
+var Actionbar = require('./components/actionbar/action-bar.js');
 var Sidebar = require('./components/sidebar/sidebar.js');
 
 var Locations = Router.Locations;
@@ -16,7 +17,8 @@ var App = React.createClass({
     return (
       <Template>
         <Sidebar />
-        <Locations className="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2 main">
+        <Actionbar />
+        <Locations className="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2 schedule-default main" id="schedule">
           <Location path='/'      handler={Week}  />
           <Location path='/week'  handler={Week}  />
           <Location path='/month' handler={Month} />

--- a/client/js/components/actionbar/action-bar.js
+++ b/client/js/components/actionbar/action-bar.js
@@ -1,0 +1,14 @@
+var React = require('react');
+var AddEvent = require('./add-event');
+
+var ActionBar = React.createClass({
+  render: function () {
+    return (
+      <div className="action-bar-default" id="action-bar">
+        <AddEvent></AddEvent>
+      </div>
+    );
+  }
+});
+
+module.exports = ActionBar;

--- a/client/js/components/actionbar/add-event.js
+++ b/client/js/components/actionbar/add-event.js
@@ -19,6 +19,7 @@ var AddEvent = React.createClass({
   render: function () {
     return (
       <div>
+        <h2>Add Event</h2>
         <form onSubmit={this.addEvent}>
           <div className="form-group">
             <div className="col-xs-12">
@@ -49,13 +50,13 @@ var AddEvent = React.createClass({
             </div>
           </div>
           <div className="form-group">
-            <div className="col-xs-4">
+            <div className="col-xs-6">
               <input type="text" placeholder="city" ref="city"></input>
             </div>
-            <div className="col-xs-4">
+            <div className="col-xs-3">
               <input type="text" placeholder="state" ref="state"></input>
             </div>
-            <div className="col-xs-4">
+            <div className="col-xs-3">
               <input type="text" placeholder="zip" ref="zip"></input>
             </div>
           </div>

--- a/client/js/components/week/week.js
+++ b/client/js/components/week/week.js
@@ -21,7 +21,6 @@ var Week = React.createClass({
   render: function () {
     return (
       <div>
-        <AddEvent />
         <WeekHeader />
         <WeekBoard days={ this.state }/>
       </div>


### PR DESCRIPTION
If you want to take the action bar for a spin, here's how:

Open up your terminal and find the DIV element that represents everything to the right of the sidebar. It'll look like this:
`<div class="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2 schedule-default main" id="schedule" data-reactid=".0.2">`

Double click on any of the classes and add the class `schedule-push-right`

Then find the DIV element that represents the action bar (which is hidden on the page but not in the terminal!). It'll look like this:
`<div class="action-bar-default" id="action-bar" data-reactid=".0.1">`

Double click on any of the classes and add the class `action-bar-open`

If you then click on any of the `:: before` lines and hit `CMD + Z` twice and then `CMD + SHIFT + Z` twice you can see the animation in action.

The idea here is that there are a ton of different ways we can add classes to DOM elements based on a clickEvent, that's the super easy part that just needs planned properly. But as you can see, once those classes are added and removed, everything works great!
